### PR TITLE
Fix default logger uses `LIFECYCLE` instead of `QUIET`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@
 
 ### Fixed
 
+- default logger uses `LIFECYCLE` instead of `QUIET`
+
 ### Updated
 
 - `com.javiersc.hubdle:com.javiersc.hubdle.gradle.plugin -> 0.4.0-alpha.17`

--- a/semver-gradle-plugin/main/kotlin/com/javiersc/semver/gradle/plugin/internal/SemVerMessages.kt
+++ b/semver-gradle-plugin/main/kotlin/com/javiersc/semver/gradle/plugin/internal/SemVerMessages.kt
@@ -1,6 +1,6 @@
 package com.javiersc.semver.gradle.plugin.internal
 
-import com.javiersc.gradle.logging.extensions.lifecycleColored
+import com.javiersc.gradle.logging.extensions.quietColored
 import com.javiersc.gradle.logging.extensions.warnColored
 import com.javiersc.kotlin.stdlib.AnsiColor
 import com.javiersc.semver.Version
@@ -8,11 +8,10 @@ import com.javiersc.semver.gradle.plugin.SemverPlugin
 import org.gradle.api.logging.Logger
 import org.gradle.api.logging.Logging
 
-internal fun semverWarningMessage(message: Any, color: AnsiColor = AnsiColor.Foreground.Yellow) =
-    defaultLogger.warnColored(color) { "$message" }
+internal fun semverWarningMessage(message: Any) = defaultLogger.warnColored { "$message" }
 
 internal fun semverMessage(message: Any, color: AnsiColor = AnsiColor.Foreground.Purple) =
-    defaultLogger.lifecycleColored(color) { "$message" }
+    defaultLogger.quietColored(color) { "$message" }
 
 internal fun warningLastVersionIsNotHigherVersion(last: Version?, higher: Version?) {
     val message =


### PR DESCRIPTION
Fix #94